### PR TITLE
Line breaks for readabiliity

### DIFF
--- a/finish/inventory/src/test/java/io/openliberty/guides/inventory/InventoryPactIT.java
+++ b/finish/inventory/src/test/java/io/openliberty/guides/inventory/InventoryPactIT.java
@@ -34,6 +34,7 @@ public class InventoryPactIT {
   @Rule
   public PactProviderRule mockProvider = new PactProviderRule("System", this);
   // end::mockprovider[]
+
   // tag::pact[]
   @Pact(consumer = "Inventory")
   // end::pact[]
@@ -57,6 +58,7 @@ public class InventoryPactIT {
       .toPact();
   }
   // end::builder[]
+
   @Pact(consumer = "Inventory")
   public RequestResponsePact createPactEdition(PactDslWithProvider builder) {
     Map<String, String> headers = new HashMap<String, String>();


### PR DESCRIPTION
Trivial update to add line breaks for readability on the website.

See screenshot below for issue.

<img width="675" alt="Screen Shot 2021-01-25 at 5 04 24 PM" src="https://user-images.githubusercontent.com/4803104/105772095-ab7b0580-5f2f-11eb-9522-667bb56832dd.png">
