### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,22 @@
 version: 2
 updates:
 - package-ecosystem: maven
-  directory: "/"
+  directory: "/finish/inventory"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50
+- package-ecosystem: maven
+  directory: "/finish/system"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50
+- package-ecosystem: maven
+  directory: "/start/inventory"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50
+- package-ecosystem: maven
+  directory: "/start/system"
   schedule:
     interval: monthly
   open-pull-requests-limit: 50

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -3,7 +3,6 @@ name: Add PRs to Dependabot PRs dashboard
 on:
   pull_request:
     types:
-      - opened
       - labeled
 
 jobs:

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,18 @@
+name: Add PRs to Dependabot PRs dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add PR to dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/26
+          github-token: ${{ secrets.ADMIN_BACKLOG }}
+          labeled: dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,10 +45,10 @@ jobs:
         working-directory: finish
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - run: unset _JAVA_OPTIONS
       - name: Run tests
         run: ../scripts/testApp.sh

--- a/README.adoc
+++ b/README.adoc
@@ -437,7 +437,7 @@ endif::[]
 ```
 docker-compose -f "pact-broker/docker-compose.yml" down
 docker rmi postgres:16.1
-docker rmi pactfoundation/pact-broker:latest-multi
+docker rmi pactfoundation/pact-broker:latest
 docker volume rm pact-broker_postgres-volume
 ```
 

--- a/README.adoc
+++ b/README.adoc
@@ -357,7 +357,7 @@ Failures:
 
 1) Verifying a pact between Inventory and System - a request for the version has a matching body
 
-    1.1) body: $.system.properties.version Expected "1.1" (String) to be a decimal number
+    1.1) body: $.system.properties.version Expected "1.x" (String) to be a decimal number
 
 
 [INFO] 

--- a/README.adoc
+++ b/README.adoc
@@ -328,7 +328,7 @@ The test target is defined in the [hotspot=context file=0]`PactVerificationConte
 
 The [hotspot=state file=0]`@State` annotation must match the [hotspot=given file=1]`given()` parameter that was provided in the `inventory` test class so that Pact can identify which test case to run against which endpoint.
 
-[role="code_command hotspot file=3", subs="quotes"]
+[role="code_command hotspot file=2", subs="quotes"]
 ----
 #Replace the system Maven project file.#
 `system/pom.xml`

--- a/README.adoc
+++ b/README.adoc
@@ -328,7 +328,7 @@ The test target is defined in the [hotspot=context file=0]`PactVerificationConte
 
 The [hotspot=state file=0]`@State` annotation must match the [hotspot=given file=1]`given()` parameter that was provided in the `inventory` test class so that Pact can identify which test case to run against which endpoint.
 
-[role="code_command hotspot file=1", subs="quotes"]
+[role="code_command hotspot file=3", subs="quotes"]
 ----
 #Replace the system Maven project file.#
 `system/pom.xml`

--- a/README.adoc
+++ b/README.adoc
@@ -436,7 +436,7 @@ endif::[]
 [role='command']
 ```
 docker-compose -f "pact-broker/docker-compose.yml" down
-docker rmi postgres:16.1
+docker rmi postgres:16.2
 docker rmi pactfoundation/pact-broker:latest
 docker volume rm pact-broker_postgres-volume
 ```

--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2023 IBM Corporation and others.
+// Copyright (c) 2022, 2024 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -436,8 +436,8 @@ endif::[]
 [role='command']
 ```
 docker-compose -f "pact-broker/docker-compose.yml" down
-docker rmi postgres:15
-docker rmi pactfoundation/pact-broker:2.106.0.1
+docker rmi postgres:16.1
+docker rmi pactfoundation/pact-broker:latest-multi
 docker volume rm pact-broker_postgres-volume
 ```
 

--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@
 :page-seo-title: Implement consumer-driven contract testing for Java microservices using the Pact framework
 :page-seo-description: A getting started tutorial with examples on how to implement consumer-driven contract testing using the Pact framework for Java microservices and cloud-native applications written using MicroProfile and Jakarta EE API.
 :guide-author: Open Liberty
-:page-tags: ['MicroProfile', 'Jakarta EE']
+:page-tags: ['microprofile', 'jakarta-ee']
 :page-related-guides: ['microshed-testing', 'reactive-service-testing', 'arquillian-managed']
 :page-permalink: /guides/{projectid}
 :repo-description: Visit the https://openliberty.io/guides/{projectid}.html[website] for the rendered version of the guide.

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.11</version>
+            <version>2.0.12</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>au.com.dius.pact.provider</groupId>
                 <artifactId>maven</artifactId>
-                <version>4.6.5</version>
+                <version>4.6.7</version>
                 <configuration>
                     <serviceProviders>
                         // tag::serviceProvider[]
@@ -88,7 +88,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.10</version>
+                <version>3.10.1</version>
             </plugin>
         </plugins>
     </build>

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -68,7 +68,7 @@
                             <name>System</name>
                             <protocol>http</protocol>
                             <host>localhost</host>
-                            <port>9080</port>
+                            <port>9090</port>
                             <path>/</path>
                             // tag::pactDirectory[]
                             <pactFileDirectory>target/pacts</pactFileDirectory>

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <!-- Liberty configuration -->
         <liberty.var.http.port>9091</liberty.var.http.port>
         <liberty.var.https.port>9454</liberty.var.https.port>

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -14,15 +14,15 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9081</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9081</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -43,12 +43,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.11</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>au.com.dius.pact.provider</groupId>
                 <artifactId>maven</artifactId>
-                <version>4.5.6</version>
+                <version>4.6.5</version>
                 <configuration>
                     <serviceProviders>
                         // tag::serviceProvider[]
@@ -94,10 +94,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <http.port>${liberty.var.default.http.port}</http.port>
+                        <http.port>${liberty.var.http.port}</http.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
         </plugins>
     </build>

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -14,8 +14,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.http.port>9081</liberty.var.http.port>
-        <liberty.var.https.port>9443</liberty.var.https.port>
+        <liberty.var.http.port>9091</liberty.var.http.port>
+        <liberty.var.https.port>9454</liberty.var.https.port>
     </properties>
 
     <dependencies>

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -5,10 +5,10 @@
       <feature>jsonb-3.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9081"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9081"/>
+  <variable name="https.port" defaultValue="9443"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint" />
 
   <webApplication location="guide-contract-testing-inventory.war" contextRoot="/"/>
 </server>

--- a/finish/inventory/src/main/liberty/config/server.xml
+++ b/finish/inventory/src/main/liberty/config/server.xml
@@ -5,8 +5,8 @@
       <feature>jsonb-3.0</feature>
   </featureManager>
 
-  <variable name="http.port" defaultValue="9081"/>
-  <variable name="https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9091"/>
+  <variable name="https.port" defaultValue="9454"/>
 
   <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint" />
 

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -10,8 +10,8 @@
     <packaging>war</packaging>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Liberty configuration -->

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -39,13 +39,13 @@
         <dependency>
             <groupId>au.com.dius.pact.provider</groupId>
             <artifactId>junit5</artifactId>
-            <version>4.6.5</version>
+            <version>4.6.7</version>
         </dependency>
         <!-- end::pactDependency[] -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.11</version>
+            <version>2.0.12</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
@@ -63,13 +63,13 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.10</version>
+                <version>3.10.1</version>
             </plugin>
             <!-- end::libertyMavenPlugin[] -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -15,8 +15,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
         <debugPort>8787</debugPort>
     </properties>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -39,18 +39,18 @@
         <dependency>
             <groupId>au.com.dius.pact.provider</groupId>
             <artifactId>junit5</artifactId>
-            <version>4.5.6</version>
+            <version>4.6.5</version>
         </dependency>
         <!-- end::pactDependency[] -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.11</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- end::libertyMavenPlugin[] -->
             <plugin>
@@ -75,10 +75,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <http.port>${liberty.var.default.http.port}</http.port>
+                        <http.port>${liberty.var.http.port}</http.port>
                         <!-- tag::version[] -->
                         <pact.provider.version>${project.version}</pact.provider.version>
                         <!-- end::version[] -->

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -15,8 +15,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Liberty configuration -->
-        <liberty.var.http.port>9080</liberty.var.http.port>
-        <liberty.var.https.port>9443</liberty.var.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
         <debugPort>8787</debugPort>
     </properties>
 

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -5,12 +5,12 @@
         <feature>jsonb-3.0</feature>
     </featureManager>
     <!-- end::features[] -->
-    <variable name="default.http.port" defaultValue="9080"/>
-    <variable name="default.https.port" defaultValue="9443"/>
+    <variable name="http.port" defaultValue="9080"/>
+    <variable name="https.port" defaultValue="9443"/>
 
     <webApplication location="guide-contract-testing-system.war" contextRoot="/" />
 
-    <httpEndpoint host="*" httpPort="${default.http.port}" 
-        httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+    <httpEndpoint host="*" httpPort="${http.port}" 
+        httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
 </server>

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -5,8 +5,8 @@
         <feature>jsonb-3.0</feature>
     </featureManager>
     <!-- end::features[] -->
-    <variable name="http.port" defaultValue="9080"/>
-    <variable name="https.port" defaultValue="9443"/>
+    <variable name="http.port" defaultValue="9090"/>
+    <variable name="https.port" defaultValue="9453"/>
 
     <webApplication location="guide-contract-testing-system.war" contextRoot="/" />
 

--- a/finish/system/src/main/webapp/js/mpData.js
+++ b/finish/system/src/main/webapp/js/mpData.js
@@ -13,7 +13,7 @@ function displayMetrics() {
 }
 
 function getSystemMetrics() {
-    var url = "http://localhost:9080/metrics";
+    var url = "http://localhost:9090/metrics";
     var req = new XMLHttpRequest();
 
     var metricToDisplay = {};
@@ -85,7 +85,7 @@ function displaySystemProperties() {
 
 function getSystemPropertiesRequest() {
     var propToDisplay = ["java.vendor", "java.version", "user.name", "os.name", "wlp.install.dir", "wlp.server.name" ];
-    var url = "http://localhost:9080/system/properties";
+    var url = "http://localhost:9090/system/properties";
     var req = new XMLHttpRequest();
     var table = document.getElementById("systemPropertiesTable");
     // Create the callback:
@@ -130,7 +130,7 @@ function displayHealth() {
 }
 
 function getHealth() {
-    var url = "http://localhost:9080/health";
+    var url = "http://localhost:9090/health";
     var req = new XMLHttpRequest();
 
     var healthBox = document.getElementById("healthBox");
@@ -172,7 +172,7 @@ function displayConfigProperties() {
 }
 
 function getConfigPropertiesRequest() {
-    var url = "http://localhost:9080/config";
+    var url = "http://localhost:9090/config";
     var req = new XMLHttpRequest();
 
     var configToDisplay = {};

--- a/pact-broker/docker-compose.yml
+++ b/pact-broker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   postgres:
-    image: postgres:16.1
+    image: postgres:16.2
     healthcheck:
       test: psql postgres --command "select 1" -U postgres
     ports:

--- a/pact-broker/docker-compose.yml
+++ b/pact-broker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   postgres:
-    image: postgres:15
+    image: postgres:16.1
     healthcheck:
       test: psql postgres --command "select 1" -U postgres
     ports:
@@ -13,7 +13,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: postgres
   pact-broker:
-    image: pactfoundation/pact-broker:2.106.0.1
+    image: pactfoundation/pact-broker:latest-multi
     restart: always
     ports:
       - "9292:9292"

--- a/pact-broker/docker-compose.yml
+++ b/pact-broker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: postgres
   pact-broker:
-    image: pactfoundation/pact-broker:latest-multi
+    image: pactfoundation/pact-broker:latest
     restart: always
     ports:
       - "9292:9292"

--- a/scripts/dailyBuild.sh
+++ b/scripts/dailyBuild.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
-while getopts t:d: flag;
+while getopts t:d:b:u:j: flag;
 do
     case "${flag}" in
         t) DATE="${OPTARG}";;
         d) DRIVER="${OPTARG}";;
+        j) JDK_LEVEL="${OPTARG}";;
         *) echo "Invalid option";;
     esac
 done
+
+if [ "$JDK_LEVEL" == "11" ]; then
+    echo "Test skipped because the guide does not support Java 11."
+    exit 0
+fi
 
 sed -i "\#<artifactId>liberty-maven-plugin</artifactId>#a<configuration><install><runtimeUrl>https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/$DATE/$DRIVER</runtimeUrl></install></configuration>" system/pom.xml inventory/pom.xml
 cat system/pom.xml inventory/pom.xml

--- a/scripts/testApp.sh
+++ b/scripts/testApp.sh
@@ -43,6 +43,6 @@ mvn -ntp failsafe:integration-test liberty:stop
 ## Remove the pact-broker application
 cd ../..
 docker-compose -f "pact-broker/docker-compose.yml" down
-docker rmi postgres:16.1
+docker rmi postgres:16.2
 docker rmi pactfoundation/pact-broker:latest
 docker volume rm pact-broker_postgres-volume

--- a/scripts/testApp.sh
+++ b/scripts/testApp.sh
@@ -44,5 +44,5 @@ mvn -ntp failsafe:integration-test liberty:stop
 cd ../..
 docker-compose -f "pact-broker/docker-compose.yml" down
 docker rmi postgres:16.1
-docker rmi pactfoundation/pact-broker:latest-multi
+docker rmi pactfoundation/pact-broker:latest
 docker volume rm pact-broker_postgres-volume

--- a/scripts/testApp.sh
+++ b/scripts/testApp.sh
@@ -43,6 +43,6 @@ mvn -ntp failsafe:integration-test liberty:stop
 ## Remove the pact-broker application
 cd ../..
 docker-compose -f "pact-broker/docker-compose.yml" down
-docker rmi postgres:15
-docker rmi pactfoundation/pact-broker:2.106.0.1
+docker rmi postgres:16.1
+docker rmi pactfoundation/pact-broker:latest-multi
 docker volume rm pact-broker_postgres-volume

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -14,15 +14,15 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9081</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9081</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -36,12 +36,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.11</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -58,10 +58,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <http.port>${liberty.var.default.http.port}</http.port>
+                        <http.port>${liberty.var.http.port}</http.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
         </plugins>
     </build>

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.11</version>
+            <version>2.0.12</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
@@ -69,7 +69,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.10</version>
+                <version>3.10.1</version>
             </plugin>
         </plugins>
     </build>

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <!-- Liberty configuration -->
         <liberty.var.http.port>9091</liberty.var.http.port>
         <liberty.var.https.port>9454</liberty.var.https.port>

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -14,8 +14,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
-        <liberty.var.http.port>9081</liberty.var.http.port>
-        <liberty.var.https.port>9443</liberty.var.https.port>
+        <liberty.var.http.port>9091</liberty.var.http.port>
+        <liberty.var.https.port>9454</liberty.var.https.port>
     </properties>
 
     <dependencies>

--- a/start/inventory/src/main/liberty/config/server.xml
+++ b/start/inventory/src/main/liberty/config/server.xml
@@ -5,10 +5,10 @@
       <feature>jsonb-3.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9081"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9081"/>
+  <variable name="https.port" defaultValue="9443"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint" />
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint" />
 
   <webApplication location="guide-contract-testing-inventory.war" contextRoot="/"/>
 </server>

--- a/start/inventory/src/main/liberty/config/server.xml
+++ b/start/inventory/src/main/liberty/config/server.xml
@@ -5,8 +5,8 @@
       <feature>jsonb-3.0</feature>
   </featureManager>
 
-  <variable name="http.port" defaultValue="9081"/>
-  <variable name="https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9091"/>
+  <variable name="https.port" defaultValue="9454"/>
 
   <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint" />
 

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -10,8 +10,8 @@
     <packaging>war</packaging>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Liberty configuration -->

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -15,8 +15,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9080</liberty.var.http.port>
+        <liberty.var.https.port>9443</liberty.var.https.port>
         <debugPort>8787</debugPort>
     </properties>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -38,12 +38,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.11</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -56,7 +56,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- end::libertyMavenPlugin[] -->
             <plugin>
@@ -68,10 +68,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <http.port>${liberty.var.default.http.port}</http.port>
+                        <http.port>${liberty.var.http.port}</http.port>
                         <pact.provider.version>${project.version}</pact.provider.version>
                     </systemPropertyVariables>
                 </configuration>

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -15,8 +15,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Liberty configuration -->
-        <liberty.var.http.port>9080</liberty.var.http.port>
-        <liberty.var.https.port>9443</liberty.var.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
         <debugPort>8787</debugPort>
     </properties>
 

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.11</version>
+            <version>2.0.12</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
@@ -56,13 +56,13 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.10</version>
+                <version>3.10.1</version>
             </plugin>
             <!-- end::libertyMavenPlugin[] -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>

--- a/start/system/src/main/java/io/openliberty/guides/system/SystemResource.java
+++ b/start/system/src/main/java/io/openliberty/guides/system/SystemResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -61,7 +61,7 @@ public class SystemResource {
   @Produces(MediaType.APPLICATION_JSON)
   public JsonObject getVersion() {
     JsonObject response = Json.createObjectBuilder()
-                              .add("system.properties.version", "1.1")
+                              .add("system.properties.version", "1.x")
                               .build();
     return response;
   }

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -5,12 +5,12 @@
         <feature>jsonb-3.0</feature>
     </featureManager>
     <!-- end::features[] -->
-    <variable name="default.http.port" defaultValue="9080"/>
-    <variable name="default.https.port" defaultValue="9443"/>
+    <variable name="http.port" defaultValue="9080"/>
+    <variable name="https.port" defaultValue="9443"/>
 
     <webApplication location="guide-contract-testing-system.war" contextRoot="/" />
 
-    <httpEndpoint host="*" httpPort="${default.http.port}" 
-        httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+    <httpEndpoint host="*" httpPort="${http.port}" 
+        httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
 </server>

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -5,8 +5,8 @@
         <feature>jsonb-3.0</feature>
     </featureManager>
     <!-- end::features[] -->
-    <variable name="http.port" defaultValue="9080"/>
-    <variable name="https.port" defaultValue="9443"/>
+    <variable name="http.port" defaultValue="9090"/>
+    <variable name="https.port" defaultValue="9453"/>
 
     <webApplication location="guide-contract-testing-system.war" contextRoot="/" />
 

--- a/start/system/src/main/webapp/js/mpData.js
+++ b/start/system/src/main/webapp/js/mpData.js
@@ -13,7 +13,7 @@ function displayMetrics() {
 }
 
 function getSystemMetrics() {
-  var url = "http://localhost:9080/metrics";
+  var url = "http://localhost:9090/metrics";
   var req = new XMLHttpRequest();
 
   var metricToDisplay = {};
@@ -85,7 +85,7 @@ function displaySystemProperties() {
 
 function getSystemPropertiesRequest() {
   var propToDisplay = ["java.vendor", "java.version", "user.name", "os.name", "wlp.install.dir", "wlp.server.name" ];
-  var url = "http://localhost:9080/system/properties";
+  var url = "http://localhost:9090/system/properties";
   var req = new XMLHttpRequest();
   var table = document.getElementById("systemPropertiesTable");
   // Create the callback:
@@ -130,7 +130,7 @@ function displayHealth() {
 }
 
 function getHealth() {
-  var url = "http://localhost:9080/health";
+  var url = "http://localhost:9090/health";
   var req = new XMLHttpRequest();
 
   var healthBox = document.getElementById("healthBox");
@@ -172,7 +172,7 @@ function displayConfigProperties() {
 }
 
 function getConfigPropertiesRequest() {
-  var url = "http://localhost:9080/config";
+  var url = "http://localhost:9090/config";
   var req = new XMLHttpRequest();
 
   var configToDisplay = {};


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [x] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [x] server.xml
  - feature version
- [x] index.html
  - feature version
- [x] update lgdev with `version-update-mp61` branch
- [x] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

